### PR TITLE
update dependencies

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        julia-version: [1.2.0]
+        julia-version: [1.6]
         julia-arch: [x86]
         os: [ubuntu-latest]
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,8 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.3'
-          - '1.5'
-          - '^1.6.0-0'
+          - '1.6'
+          - '1.10'
         os:
           - ubuntu-latest
           - macOS-latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,17 +1,18 @@
 name = "OscillatoryIntegrals"
 uuid = "36d79ec0-be04-40c6-b002-a7ecbe3190c2"
 authors = ["Sheehan Olver <solver@mac.com>"]
-version = "0.0.2"
+version = "0.0.3"
 
 [deps]
 ApproxFun = "28f2ccd6-bb30-5033-b560-165f7b14dc2f"
+ApproxFunBase = "fbd15aa5-315a-5a7d-a8a4-24992e37be05"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
 [compat]
-ApproxFun = "0.11, 0.12"
-SpecialFunctions = "0.7, 0.8, 0.9, 0.10, 1"
-julia = "1.3"
+ApproxFun = "0.11, 0.12, 0.13"
+SpecialFunctions = "0.7, 0.8, 0.9, 0.10, 1, 2"
+julia = "1.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/OscillatoryIntegrals.jl
+++ b/src/OscillatoryIntegrals.jl
@@ -2,8 +2,8 @@
 module OscillatoryIntegrals
 using Base, ApproxFun, LinearAlgebra, SpecialFunctions
 
-import ApproxFun: domain, evaluate, spacescompatible,
-					SpaceOperator, ConstantSpace
+import ApproxFun: domain, evaluate
+import ApproxFunBase: spacescompatible
 
 include("Bessel.jl")
 


### PR DESCRIPTION
Update:

- SpecialFunctions: 2
- ApproxFun: 0.13
- Julia: 1.6 (ApproxFun 0.13)

Imports:

- `ApproxFun`no longer imports `spacescompatible`, instead need to import directly from `ApproxFunBase` which was added as a new dependency
-  removed imports of `SpaceOperator` and`ConstantSpace` which were not used